### PR TITLE
Change osname of Windows systems to comply with OSGI spec

### DIFF
--- a/org.lwjgl.assimp/pom.xml
+++ b/org.lwjgl.assimp/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   assimp32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   assimp.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   libassimp.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.bgfx/pom.xml
+++ b/org.lwjgl.bgfx/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   bgfx32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   bgfx.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   libbgfx.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.glfw/pom.xml
+++ b/org.lwjgl.glfw/pom.xml
@@ -254,10 +254,10 @@
 
                 <Bundle-NativeCode>
                   glfw32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   glfw.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   libglfw.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.lmdb/pom.xml
+++ b/org.lwjgl.lmdb/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_lmdb32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_lmdb.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_lmdb.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.lwjgl/pom.xml
+++ b/org.lwjgl.lwjgl/pom.xml
@@ -364,11 +364,11 @@
                 <Bundle-NativeCode>
                   lwjgl32.dll;
                   jemalloc32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl.dll;
                   jemalloc.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl.so;
                   libjemalloc.so;

--- a/org.lwjgl.nanovg/pom.xml
+++ b/org.lwjgl.nanovg/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_nanovg32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_nanovg.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_nanovg.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.nfd/pom.xml
+++ b/org.lwjgl.nfd/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_nfd32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_nfd.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_nfd.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.nuklear/pom.xml
+++ b/org.lwjgl.nuklear/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_nuklear32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_nuklear.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_nuklear.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.openal/pom.xml
+++ b/org.lwjgl.openal/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   OpenAL32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   OpenAL.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   libopenal.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.opengl/pom.xml
+++ b/org.lwjgl.opengl/pom.xml
@@ -246,10 +246,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_opengl32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_opengl.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_opengl.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.opengles/pom.xml
+++ b/org.lwjgl.opengles/pom.xml
@@ -244,10 +244,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_opengles32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_opengles.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_opengles.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.ovr/pom.xml
+++ b/org.lwjgl.ovr/pom.xml
@@ -186,10 +186,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_ovr32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_ovr.dll;
-                  osname=Windows; processor=x86-64
+                  osname=Win32; processor=x86-64
                 </Bundle-NativeCode>
 
                 <Specification-Title>Lightweight Java Game Library</Specification-Title>

--- a/org.lwjgl.par/pom.xml
+++ b/org.lwjgl.par/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_par32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_par.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_par.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.sse/pom.xml
+++ b/org.lwjgl.sse/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_sse32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_sse.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_sse.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.stb/pom.xml
+++ b/org.lwjgl.stb/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_stb32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_stb.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_stb.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.tinyfd/pom.xml
+++ b/org.lwjgl.tinyfd/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_tinyfd32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_tinyfd.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_tinyfd.so;
                   osname=Linux; processor=x86-64,

--- a/org.lwjgl.xxhash/pom.xml
+++ b/org.lwjgl.xxhash/pom.xml
@@ -238,10 +238,10 @@
 
                 <Bundle-NativeCode>
                   lwjgl_xxhash32.dll;
-                  osname=Windows; processor=x86,
+                  osname=Win32; processor=x86,
 
                   lwjgl_xxhash.dll;
-                  osname=Windows; processor=x86-64,
+                  osname=Win32; processor=x86-64,
 
                   liblwjgl_xxhash.so;
                   osname=Linux; processor=x86-64,


### PR DESCRIPTION
This fixes the issues on Windows described in https://github.com/LWJGL/lwjgl3-osgi/issues/3

I tested it in the following way:
- compiled the plugin with "mvn clean verify" and used in my Eclipse plugin.
- System: Windows 10 (two systems, one usual Windows host and a Windows guest in a vbox on Ubuntu), x_86
- OSGI-Implementation: Equinox of Mars Eclipse IDE
- Archives: org.lwjgl.lwjgl and org.lwjgl.opengl

Result:
There seem to be no issues now.
